### PR TITLE
Fixes #2 - Handle windows directory separator

### DIFF
--- a/src/fs-functions.ts
+++ b/src/fs-functions.ts
@@ -1,5 +1,5 @@
 import { readdir } from 'fs';
-import { resolve as resolvePath } from 'path';
+import { resolve as resolvePath, sep as dirSeparator } from 'path';
 
 export function getChildrenOfPath(path) {
     return new Promise<string[]>((resolve, reject) => {
@@ -14,7 +14,7 @@ export function getChildrenOfPath(path) {
 }
 
 export function getPath(fileName: string, text: string) : string {
-    return resolvePath(fileName.substring(0, fileName.lastIndexOf("/")), text);
+    return resolvePath(fileName.substring(0, fileName.lastIndexOf(dirSeparator)), text);
 }
 
 function hiddenFiles(filename) {


### PR DESCRIPTION
Use `path.sep` provided by the fs api to get the appropriate directory separator.