### PR TITLE
Move the checking for paths after we know it's an import we can use

### DIFF
--- a/src/PathIntellisense.ts
+++ b/src/PathIntellisense.ts
@@ -13,9 +13,10 @@ export class PathIntellisense implements CompletionItemProvider {
         const isImport = isImportOrRequire(line);
         const documentExtension = extractExtension(document);
         const textWithinString = getTextWithinString(line, position.character);
-        const path = getPath(document.fileName, textWithinString);
-
+        
         if (this.shouldProvide(textWithinString, isImport)) {
+            const path = getPath(document.fileName, textWithinString);
+        
             return this.getChildrenOfPath(path).then(children => {
                 return [
                     new UpCompletionItem(),

--- a/src/fs-functions.ts
+++ b/src/fs-functions.ts
@@ -9,18 +9,11 @@ export function getChildrenOfPath(path) {
         .catch(() => []);
 }
 
-export function getPath(fileName: string, text: string) : string {
-    console.log(fileName);
-    console.log(text);
-    console.log(normalize(text));
-    
-    console.log(fileName.substring(0, fileName.lastIndexOf(dirSeparator)));
-    console.log(text.substring(0, text.lastIndexOf(dirSeparator)));
-    console.log(normalize(text).substring(0, normalize(text).lastIndexOf(dirSeparator)));
-    console.log('====');
-    
-    
-    return resolvePath(fileName.substring(0, fileName.lastIndexOf(dirSeparator)), normalize(text).substring(0, normalize(text).lastIndexOf(dirSeparator)));;
+export function getPath(fileName: string, text: string) : string {    
+    const referencedFolder = fileName.substring(0, fileName.lastIndexOf(dirSeparator));
+    const lastFolderInText = normalize(text).substring(0, normalize(text).lastIndexOf(dirSeparator));
+
+    return resolvePath(referencedFolder, lastFolderInText);
 }
 
 export function extractExtension(document: TextDocument) {


### PR DESCRIPTION
This should fix #11 - I took a stab at naming some of the variables inside `getPath` while looking around, and removed the console logs. I can't reproduce the crash now with the new version 👍 

Thanks for the extension, it's a useful piece of software. I miss it in other editors.