### PR TITLE
Fix: Incorrect markdown rendering for history

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,38 @@ Define custom mappings which can be useful for using absolute paths or in combin
 Use ${workspaceRoot} when the path should be relative to the current root of the current project.
 
 ## History
+
 ### v1.1.0
 - [Feature] Custom Mappings #19, #5
 - [Feature] Setting to enable display of hidden files #12
 - [Bug] Fixed #11
+
 ### v1.0.2
 - [Bug] Fixed #15
 - [Bug] Fixed #16
+
 ### v1.0.1
 - Fixed compatibility with VS Code 1.3
+
 ### v1.0.0
 - [Feature] Added .. on top of each suggestion, Removed trailing slash
 - [Bugs] Various bugs fixed
+
 ### v0.2.0
 - [Feature] Remove file extension within imports (configurable)
+
 ### v0.1.0
 - Added slash after folders, group by folder and files, file icon
+
 ### v0.0.5 
 - Fixed windows path issue
+
 ### v0.0.3 
 - Fixed unknown publisher issue
+
 ### v0.0.2 
 - Updated Readme.md
+
 ### v0.0.1 
 - Initial 
 


### PR DESCRIPTION
Blank lines has been added before each header in History section.