### PR TITLE
Dash names fix

### DIFF
--- a/src/PathCompletionItem.ts
+++ b/src/PathCompletionItem.ts
@@ -1,14 +1,17 @@
-import { CompletionItem, CompletionItemKind } from 'vscode';
+import { CompletionItem, CompletionItemKind, Range, TextEdit } from 'vscode';
 import { FileInfo } from './FileInfo';
 import { workspace } from 'vscode';
 
 const withExtension = workspace.getConfiguration('path-intellisense')['extensionOnImport'];
 
 export class PathCompletionItem extends CompletionItem {
-    constructor(fileInfo: FileInfo, isImport: boolean, documentExtension: string) {
+    private importRange: Range;
+    
+    constructor(fileInfo: FileInfo, importRange: Range, isImport: boolean, documentExtension: string) {
         super(fileInfo.file);
         
         this.kind = CompletionItemKind.File;
+        this.importRange = importRange;
         
         this.addGroupByFolderFile(fileInfo);
         this.removeExtension(fileInfo, isImport, documentExtension);
@@ -22,7 +25,7 @@ export class PathCompletionItem extends CompletionItem {
     addSlashForFolder(fileInfo: FileInfo) {
         if (!fileInfo.isFile) {
             this.label = `${fileInfo.file}/`;
-            this.insertText = fileInfo.file; 
+            this.textEdit = new TextEdit(this.importRange, fileInfo.file);
         }
     }
     
@@ -39,6 +42,7 @@ export class PathCompletionItem extends CompletionItem {
         }
 
         let index = fileInfo.file.lastIndexOf('.');
-        this.insertText = index != -1 ? fileInfo.file.substring(0, index) : fileInfo.file;
+        const name = index != -1 ? fileInfo.file.substring(0, index) : fileInfo.file;
+        this.textEdit = new TextEdit(this.importRange, name);
     }
 }

--- a/src/PathIntellisense.ts
+++ b/src/PathIntellisense.ts
@@ -1,4 +1,4 @@
-import { CompletionItemProvider, TextDocument, Position, CompletionItem, workspace } from 'vscode';
+import { CompletionItemProvider, TextDocument, Position, CompletionItem, Range, workspace } from 'vscode';
 import { isImportOrRequire, getTextWithinString } from './text-parser';
 import { getPath, extractExtension, Mapping } from './fs-functions';
 import { PathCompletionItem } from './PathCompletionItem';
@@ -11,6 +11,7 @@ export class PathIntellisense implements CompletionItemProvider {
     provideCompletionItems(document: TextDocument, position: Position): Thenable<CompletionItem[]> {
         const textCurrentLine = document.getText(document.lineAt(position).range);
         const textWithinString = getTextWithinString(textCurrentLine, position.character);
+        const importRange = this.importStringRange(document, position);
         const isImport = isImportOrRequire(textCurrentLine);
         const documentExtension = extractExtension(document);
         const mappings = this.getMappings();
@@ -19,7 +20,7 @@ export class PathIntellisense implements CompletionItemProvider {
             return Promise.resolve([]);
         }
         
-        return this.provide(document.fileName, textWithinString, mappings, isImport, documentExtension);
+        return this.provide(document.fileName, textWithinString, mappings, isImport, documentExtension, importRange);
     }
 
     shouldProvide(textWithinString: string, isImport: boolean, mappings?: Mapping[]) {
@@ -38,13 +39,24 @@ export class PathIntellisense implements CompletionItemProvider {
         return false;
     }
 
-    provide(fileName, textWithinString, mappings, isImport, documentExtension) {
+    provide(fileName, textWithinString, mappings, isImport, documentExtension, importRange) {
         const path = getPath(fileName, textWithinString, mappings);
         
         return this.getChildrenOfPath(path).then(children => ([
             new UpCompletionItem(),
-            ...children.map(child => new PathCompletionItem(child, isImport, documentExtension))
+            ...children.map(child => new PathCompletionItem(child, importRange, isImport, documentExtension))
         ]));
+    }
+
+    importStringRange(document: TextDocument, position: Position): Range {
+        const line = document.getText(document.lineAt(position).range);
+        const textToPosition = line.substring(0, position.character);
+        const slashPosition = textToPosition.lastIndexOf('/');
+
+        const startPosition = new Position(position.line, slashPosition + 1);
+        const endPosition = position;
+
+        return new Range(startPosition, endPosition);
     }
 
     getMappings(): Mapping[] {

--- a/src/PathIntellisense.ts
+++ b/src/PathIntellisense.ts
@@ -1,5 +1,5 @@
-import { CompletionItemProvider, TextDocument, Position, CompletionItem, Range, workspace } from 'vscode';
-import { isImportOrRequire, getTextWithinString } from './text-parser';
+import { CompletionItemProvider, TextDocument, Position, CompletionItem, workspace } from 'vscode';
+import { isImportOrRequire, getTextWithinString, importStringRange } from './text-parser';
 import { getPath, extractExtension, Mapping } from './fs-functions';
 import { PathCompletionItem } from './PathCompletionItem';
 import { UpCompletionItem } from './UpCompletionItem';
@@ -11,7 +11,7 @@ export class PathIntellisense implements CompletionItemProvider {
     provideCompletionItems(document: TextDocument, position: Position): Thenable<CompletionItem[]> {
         const textCurrentLine = document.getText(document.lineAt(position).range);
         const textWithinString = getTextWithinString(textCurrentLine, position.character);
-        const importRange = this.importStringRange(document, position);
+        const importRange = importStringRange(textCurrentLine, position);
         const isImport = isImportOrRequire(textCurrentLine);
         const documentExtension = extractExtension(document);
         const mappings = this.getMappings();
@@ -46,17 +46,6 @@ export class PathIntellisense implements CompletionItemProvider {
             new UpCompletionItem(),
             ...children.map(child => new PathCompletionItem(child, importRange, isImport, documentExtension))
         ]));
-    }
-
-    importStringRange(document: TextDocument, position: Position): Range {
-        const line = document.getText(document.lineAt(position).range);
-        const textToPosition = line.substring(0, position.character);
-        const slashPosition = textToPosition.lastIndexOf('/');
-
-        const startPosition = new Position(position.line, slashPosition + 1);
-        const endPosition = position;
-
-        return new Range(startPosition, endPosition);
     }
 
     getMappings(): Mapping[] {

--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -1,3 +1,5 @@
+import { Range, Position, TextDocument } from 'vscode';
+
 export function isInString(text: string, character: number) : boolean {
     let inSingleQuoationString = (text.substring(0, character).match(/\'/g) || []).length % 2 === 1;
     let inDoubleQuoationString = (text.substring(0, character).match(/\"/g) || []).length % 2 === 1;
@@ -14,4 +16,14 @@ export function getTextWithinString(text: string, position: number) {
     const textToPosition = text.substring(0, position);
     const quoatationPosition = Math.max(textToPosition.lastIndexOf('\"'), textToPosition.lastIndexOf('\''));
     return quoatationPosition != -1 ? textToPosition.substring(quoatationPosition + 1, textToPosition.length) : undefined;
+}
+
+export function importStringRange(line: string, position: Position): Range {
+    const textToPosition = line.substring(0, position.character);
+    const slashPosition = textToPosition.lastIndexOf('/');
+
+    const startPosition = new Position(position.line, slashPosition + 1);
+    const endPosition = position;
+
+    return new Range(startPosition, endPosition);
 }

--- a/test/text-parser.test.ts
+++ b/test/text-parser.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import { isImportOrRequire, getTextWithinString } from '../src/text-parser';
+import { Position } from 'vscode';
+import { isImportOrRequire, getTextWithinString, importStringRange } from '../src/text-parser';
 
 suite("Text Parser Tests", () => {
 
@@ -18,4 +19,17 @@ suite("Text Parser Tests", () => {
         assert.equal('hell', getTextWithinString("require('hello')", 13));
         assert.equal('', getTextWithinString("require('hello')", 15));
     });
+
+    test("importStringRange", () => {
+        const requireRange = importStringRange("const test = require('./file')", new Position(0, 28));
+        assert.equal(requireRange.end.line, requireRange.start.line, 'Require range line index');
+        assert.equal(requireRange.start.character, 24, 'Require range start character');
+        assert.equal(requireRange.end.character, 28, 'Require range end character');
+
+        const importRange = importStringRange("import testing from './some-file';", new Position(0, 33));
+        assert.equal(importRange.end.line, importRange.start.line, 'Import range line index');
+        assert.equal(importRange.start.character, 23, 'Import range start character');
+        assert.equal(importRange.end.character, 33, 'Import range end character');
+    });
+
 });


### PR DESCRIPTION
This PR is somehow connected with the [one from NpmIntellisense repo](https://github.com/ChristianKohler/NpmIntellisense/pull/19).

Fixes autocompletion for names with dashes. e.g.
having `my-file.js` in current directory:

``` js
import myModule from './my-f|';
                            ^
```

And choosing `my-file` from the suggestions would give you the result:

``` js
import myModule from './my-my-file';
```

instead of

``` js
import myModule from './my-file';
```

This PR fixes this bug.
