### PR TITLE
Add Option to automatically add a slash after directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Per default, hidden files are not displayed. Set this to true to show hidden fil
 }
 ```
 
+### Auto Slash when navigating to folder
+Per default, the autocompletion does not add a slash after a directory.
+```javascript
+{
+	"path-intellisense.autoSlashAfterDirectory": false,
+}
+```
+
 ### Mappings
 Define custom mappings which can be useful for using absolute paths or in combination with webpack resolve options.
 

--- a/src/PathCompletionItem.ts
+++ b/src/PathCompletionItem.ts
@@ -1,6 +1,7 @@
 import { CompletionItem, CompletionItemKind } from 'vscode';
 import { FileInfo } from './FileInfo';
 import { workspace } from 'vscode';
+import { shallAutoSlash as shallAutoSlashAfterFolder} from './config';
 
 const withExtension = workspace.getConfiguration('path-intellisense')['extensionOnImport'];
 
@@ -22,7 +23,12 @@ export class PathCompletionItem extends CompletionItem {
     addSlashForFolder(fileInfo: FileInfo) {
         if (!fileInfo.isFile) {
             this.label = `${fileInfo.file}/`;
-            this.insertText = fileInfo.file; 
+           
+            if(shallAutoSlashAfterFolder()) {
+              this.insertText = `${fileInfo.file}/`; 
+            } else {
+              this.insertText = `${fileInfo.file}`; 
+            }
         }
     }
     

--- a/src/PathIntellisense.ts
+++ b/src/PathIntellisense.ts
@@ -3,6 +3,7 @@ import { isImportOrRequire, getTextWithinString } from './text-parser';
 import { getPath, extractExtension, Mapping } from './fs-functions';
 import { PathCompletionItem } from './PathCompletionItem';
 import { UpCompletionItem } from './UpCompletionItem';
+import { shallAutoSlash } from './config';
 
 export class PathIntellisense implements CompletionItemProvider {
     
@@ -40,11 +41,12 @@ export class PathIntellisense implements CompletionItemProvider {
 
     provide(fileName, textWithinString, mappings, isImport, documentExtension) {
         const path = getPath(fileName, textWithinString, mappings);
-        
-        return this.getChildrenOfPath(path).then(children => ([
-            new UpCompletionItem(),
-            ...children.map(child => new PathCompletionItem(child, isImport, documentExtension))
-        ]));
+        if(textWithinString.endsWith("/")) {
+          return this.getChildrenOfPath(path).then(children => ([
+              new UpCompletionItem(),
+              ...children.map(child => new PathCompletionItem(child, isImport, documentExtension))
+          ]));
+        } else return [];
     }
 
     getMappings(): Mapping[] {

--- a/src/UpCompletionItem.ts
+++ b/src/UpCompletionItem.ts
@@ -1,8 +1,9 @@
 import { CompletionItem, CompletionItemKind } from 'vscode';
+import { shallAutoSlash } from './config';
 
 export class UpCompletionItem extends CompletionItem {
     constructor() {
-        super('..');
+        super(`..${shallAutoSlash() ? '/' : ''}`);
         this.kind = CompletionItemKind.File;
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+import {workspace} from 'vscode';
+
+export function shallAutoSlash() {
+     const autoSlashAfterFolder : Boolean = workspace.getConfiguration('path-intellisense')['autoSlashAfterDirectory'];
+     return autoSlashAfterFolder;
+}


### PR DESCRIPTION
As an IntelliJ User i feel like this is how navigating through the paths should be like.

Old workflow:
![old](https://cloud.githubusercontent.com/assets/8105746/20455228/4365cdfa-ae57-11e6-979c-d0a2e1a4b718.gif)

With path-intellisense.autoSlashAfterDirectory = true
![new gif](https://cloud.githubusercontent.com/assets/8105746/20455232/59e3f200-ae57-11e6-8268-b396115fa89d.gif)

