### PR TITLE
tsconfig.json parse & hidden file problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "vscode": "^0.11.0"
   },
   "dependencies": {
+    "json5": "0.5.1",
     "minimatch": "^3.0.4"
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,7 @@
 import { workspace, WorkspaceConfiguration } from 'vscode';
 import { Mapping } from "./fs-functions";
 import { readFileSync } from "fs";
+import * as JSON from 'json5';
 
 export interface Config {
     autoSlash: boolean,
@@ -25,7 +26,7 @@ export function getConfig(tsconfig?): Config {
 }
 
 export function getTsConfig() {
-    return workspace.findFiles('tsconfig.json', '**/node_modules/**').then(files => {   
+    return workspace.findFiles('tsconfig.json', '**/node_modules/**').then(files => {
         if (files && files[0]) {
             return JSON.parse(readFileSync(files[0].fsPath).toString());
         } else {


### PR DESCRIPTION
1. `tsconfig.json` support comment, so you should use `json5` to parse the file content
2. vscode config `files.exclude` should prefix the workspace rootPath when use `minimatch`
 
For example:

```js
// vscode config
"files.exclude":  {
  "foo": true  // only hidden the "foo" director in workspace root
}
```
but `src/foo/` folder will be hidden in original version.

So in this version I'm using the full file path to match.

