### PR TITLE
Add multi-root support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.4.2",
   "publisher": "christian-kohler",
   "engines": {
-    "vscode": "^1.0.0"
+    "vscode": "^1.18.0"
   },
   "homepage": "https://github.com/ChristianKohler/PathIntellisense",
   "repository": {
@@ -14,6 +14,9 @@
   },
   "categories": [
     "Other"
+  ],
+  "keywords": [
+    "multi-root ready"
   ],
   "activationEvents": [
     "*"
@@ -24,26 +27,31 @@
       "title": "path-intellisense",
       "properties": {
         "path-intellisense.extensionOnImport": {
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "Adds the file extension to a import statements"
         },
         "path-intellisense.mappings": {
+          "scope": "resource",
           "type": "object",
           "default": {},
           "description": "Mappings for paths"
         },
         "path-intellisense.showHiddenFiles": {
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "Show hidden files"
         },
         "path-intellisense.autoSlashAfterDirectory": {
+          "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "Automatically adds slash after directory"
         },
         "path-intellisense.absolutePathToWorkspace": {
+          "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "Sets an absolute path to the current workspace"

--- a/src/completionItems/UpCompletionItem.ts
+++ b/src/completionItems/UpCompletionItem.ts
@@ -1,9 +1,9 @@
 import { CompletionItem, CompletionItemKind } from 'vscode';
-import { getConfig } from '../utils/config';
+import { Config } from '../utils/config';
 
 export class UpCompletionItem extends CompletionItem {
-    constructor() {
-        super(`..${getConfig().autoSlash ? '/' : ''}`);
+    constructor(config: Config) {
+        super(`..${config.autoSlash ? '/' : ''}`);
         this.kind = CompletionItemKind.File;
     }
 }


### PR DESCRIPTION
Hi @ChristianKohler,

This PR adds support for multiple root folders in the same VS Code window. That requires VS Code 1.18.0 or later.

Please take a close look, I'm not familiar with your extension and might have overlooked some cases.

Cheers,

Christof