### PR TITLE
fix: Prefer using HTTPS links for "IDE GIF" and "MIT License" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Visual Studio Code plugin that autocompletes filenames.
 In the command palette (cmd-shift-p) select Install Extension and choose Path Intellisense.
 
 ## Usage
-![IDE](http://i.giphy.com/iaHeUiDeTUZuo.gif)
+![IDE](https://i.giphy.com/iaHeUiDeTUZuo.gif)
 
 ## Node packages intellisense
 Use [npm intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense)
@@ -108,4 +108,4 @@ Use ${workspaceRoot} when the path should be relative to the current root of the
 See changelog
 
 ## License
-This software is released under [MIT License](http://www.opensource.org/licenses/mit-license.php)
+This software is released under [MIT License](https://www.opensource.org/licenses/mit-license.php)


### PR DESCRIPTION
Hi there! 👋

I noticed a few insecure HTTP links in README.md that could be HTTPS instead. 🙂

HTTPS will work equally well, and avoids problems like "Mixed Content" security warnings in web browsers, and linting problems like shown in https://github.com/open-vsx/publish-extensions/issues/3.