### PR TITLE
Enable your extension to run on VS Code for the web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modulesout
 node_modules
 .vscode-test/
 *.vsix
+dist

--- a/build/web-extension.webpack.config.js
+++ b/build/web-extension.webpack.config.js
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+'use strict';
+
+//@ts-check
+/** @typedef {import('webpack').Configuration} WebpackConfig **/
+
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = /** @type WebpackConfig */ {
+	context: path.dirname(__dirname),
+	mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+	target: 'webworker', // extensions run in a webworker context
+	entry: {
+		'extension': './src/extension.ts'
+	},
+	resolve: {
+		mainFields: ['module', 'main'],
+		extensions: ['.ts', '.js'], // support ts-files and js-files
+		alias: {
+		},
+		fallback: {
+			'assert': require.resolve('assert'),
+            'path': require.resolve('path-browserify')
+		}
+	},
+	module: {
+		rules: [{
+			test: /\.ts$/,
+			exclude: /node_modules/,
+			use: [
+				{
+					loader: 'ts-loader'
+				}
+			]
+		}]
+	},
+	plugins: [
+		new webpack.ProvidePlugin({
+			process: 'process/browser',
+		}),
+	],
+	externals: {
+		'vscode': 'commonjs vscode', // ignored because it doesn't exist
+	},
+	performance: {
+		hints: false
+	},
+	output: {
+		filename: '[name].js',
+		path: path.join(__dirname, '../dist/web'),
+		libraryTarget: 'commonjs'
+	},
+	devtool: 'nosources-source-map'
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "path-intellisense",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -29,6 +29,12 @@
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
+		},
+		"@discoveryjs/json-ext": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
+			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
+			"dev": true
 		},
 		"@semantic-release/changelog": {
 			"version": "5.0.1",
@@ -105,10 +111,36 @@
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
 		},
+		"@types/eslint": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
+			"integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"@types/eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"dev": true,
+			"requires": {
+				"@types/eslint": "*",
+				"@types/estree": "*"
+			}
+		},
 		"@types/eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+			"dev": true
+		},
+		"@types/estree": {
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
 		"@types/events": {
@@ -220,10 +252,195 @@
 				"tsutils": "^3.17.1"
 			}
 		},
+		"@webassemblyjs/ast": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/helper-numbers": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+			}
+		},
+		"@webassemblyjs/floating-point-hex-parser": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"dev": true
+		},
+		"@webassemblyjs/helper-api-error": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"dev": true
+		},
+		"@webassemblyjs/helper-buffer": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"dev": true
+		},
+		"@webassemblyjs/helper-numbers": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
+				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"@webassemblyjs/helper-wasm-bytecode": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"dev": true
+		},
+		"@webassemblyjs/helper-wasm-section": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-buffer": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/wasm-gen": "1.11.1"
+			}
+		},
+		"@webassemblyjs/ieee754": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"dev": true,
+			"requires": {
+				"@xtuc/ieee754": "^1.2.0"
+			}
+		},
+		"@webassemblyjs/leb128": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"dev": true,
+			"requires": {
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"@webassemblyjs/utf8": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"dev": true
+		},
+		"@webassemblyjs/wasm-edit": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-buffer": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/helper-wasm-section": "1.11.1",
+				"@webassemblyjs/wasm-gen": "1.11.1",
+				"@webassemblyjs/wasm-opt": "1.11.1",
+				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@webassemblyjs/wast-printer": "1.11.1"
+			}
+		},
+		"@webassemblyjs/wasm-gen": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/ieee754": "1.11.1",
+				"@webassemblyjs/leb128": "1.11.1",
+				"@webassemblyjs/utf8": "1.11.1"
+			}
+		},
+		"@webassemblyjs/wasm-opt": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-buffer": "1.11.1",
+				"@webassemblyjs/wasm-gen": "1.11.1",
+				"@webassemblyjs/wasm-parser": "1.11.1"
+			}
+		},
+		"@webassemblyjs/wasm-parser": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/ieee754": "1.11.1",
+				"@webassemblyjs/leb128": "1.11.1",
+				"@webassemblyjs/utf8": "1.11.1"
+			}
+		},
+		"@webassemblyjs/wast-printer": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.11.1",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"@webpack-cli/configtest": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
+			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+			"dev": true
+		},
+		"@webpack-cli/info": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
+			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+			"dev": true,
+			"requires": {
+				"envinfo": "^7.7.3"
+			}
+		},
+		"@webpack-cli/serve": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
+			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+			"dev": true
+		},
+		"@xtuc/ieee754": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true
+		},
+		"@xtuc/long": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true
+		},
 		"acorn": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
 			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"dev": true
+		},
+		"acorn-import-assertions": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
+			"integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -262,6 +479,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"ajv-keywords": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true
 		},
 		"ansi-colors": {
 			"version": "3.2.3",
@@ -332,6 +555,12 @@
 			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
 		},
+		"available-typed-arrays": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+			"integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==",
+			"dev": true
+		},
 		"azure-devops-node-api": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
@@ -394,11 +623,40 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
+		"browserslist": {
+			"version": "4.16.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.811",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.75"
+			}
+		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true
+		},
+		"buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -410,6 +668,12 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001251",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
 			"dev": true
 		},
 		"chalk": {
@@ -458,6 +722,12 @@
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.2.0"
 			}
+		},
+		"chrome-trace-event": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"dev": true
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -516,6 +786,17 @@
 				}
 			}
 		},
+		"clone-deep": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"dev": true,
+			"requires": {
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -529,6 +810,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"colorette": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+			"integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
 			"dev": true
 		},
 		"commander": {
@@ -688,6 +975,12 @@
 				"domelementtype": "1"
 			}
 		},
+		"electron-to-chromium": {
+			"version": "1.3.813",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
+			"integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
+			"dev": true
+		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -703,10 +996,26 @@
 				"once": "^1.4.0"
 			}
 		},
+		"enhanced-resolve": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
+			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			}
+		},
 		"entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+			"dev": true
+		},
+		"envinfo": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
 		"error-ex": {
@@ -737,6 +1046,12 @@
 				"string.prototype.trimright": "^2.1.1"
 			}
 		},
+		"es-module-lexer": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
+			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+			"dev": true
+		},
 		"es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -762,6 +1077,12 @@
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -911,6 +1232,12 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true
+		},
 		"execa": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
@@ -1000,6 +1327,12 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fastest-levenshtein": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+			"dev": true
+		},
 		"fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -1071,6 +1404,12 @@
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -1114,6 +1453,17 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
 		"get-stream": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
@@ -1146,6 +1496,12 @@
 				"is-glob": "^4.0.1"
 			}
 		},
+		"glob-to-regexp": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true
+		},
 		"globals": {
 			"version": "12.4.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -1176,6 +1532,12 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"has-bigints": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"dev": true
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1187,6 +1549,23 @@
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
+		},
+		"has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
+			}
 		},
 		"he": {
 			"version": "1.2.0",
@@ -1291,6 +1670,16 @@
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
+			}
+		},
+		"import-local": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -1409,11 +1798,47 @@
 				}
 			}
 		},
+		"internal-slot": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			}
+		},
+		"interpret": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+			"dev": true
+		},
+		"is-arguments": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
+		},
+		"is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -1422,6 +1847,16 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
+			}
+		},
+		"is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -1454,6 +1889,15 @@
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true
 		},
+		"is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -1463,11 +1907,35 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
+		},
+		"is-number-object": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -1490,6 +1958,15 @@
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
+		"is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-symbol": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -1499,11 +1976,145 @@
 				"has-symbols": "^1.0.1"
 			}
 		},
+		"is-typed-array": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.7.tgz",
+			"integrity": "sha512-VxlpTBGknhQ3o7YiVjIhdLU6+oD8dPz/79vvvH4F+S/c8608UCVa9fgDpa1kZgFoUST2DCgacc70UszKgzKuvA==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.4",
+				"call-bind": "^1.0.2",
+				"es-abstract": "^1.18.5",
+				"foreach": "^2.0.5",
+				"has-tostringtag": "^1.0.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+					"integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"jest-worker": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -1557,6 +2168,12 @@
 				"universalify": "^1.0.0"
 			}
 		},
+		"kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true
+		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -1588,6 +2205,12 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
+		"loader-runner": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+			"dev": true
+		},
 		"locate-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -1610,6 +2233,15 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
+			}
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
 			}
 		},
 		"markdown-it": {
@@ -1660,6 +2292,21 @@
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"dev": true
+		},
+		"mime-db": {
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+			"integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.32",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+			"integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.49.0"
+			}
 		},
 		"mimic-fn": {
 			"version": "2.1.0",
@@ -1794,6 +2441,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
 		"nerf-dart": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
@@ -1823,6 +2476,12 @@
 					"dev": true
 				}
 			}
+		},
+		"node-releases": {
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -5589,6 +6248,12 @@
 				"@types/node": "*"
 			}
 		},
+		"path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true
+		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -5631,6 +6296,51 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^4.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				}
+			}
+		},
 		"platform": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
@@ -5640,6 +6350,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
 			"dev": true
 		},
 		"progress": {
@@ -5663,6 +6379,15 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"rc": {
 			"version": "1.2.8",
@@ -5733,6 +6458,15 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"rechoir": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.9.0"
+			}
+		},
 		"regexpp": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
@@ -5767,6 +6501,23 @@
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
 			}
 		},
 		"resolve-from": {
@@ -5824,17 +6575,66 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"schema-utils": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "^7.0.8",
+				"ajv": "^6.12.5",
+				"ajv-keywords": "^3.5.2"
+			},
+			"dependencies": {
+				"@types/json-schema": {
+					"version": "7.0.9",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				}
+			}
+		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
 		},
+		"serialize-javascript": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
+		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
+		},
+		"shallow-clone": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^6.0.2"
+			}
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -5850,6 +6650,25 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
+		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"dependencies": {
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+					"dev": true
+				}
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.3",
@@ -5874,6 +6693,22 @@
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				}
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"spdx-correct": {
@@ -6062,6 +6897,12 @@
 				}
 			}
 		},
+		"tapable": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+			"integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+			"dev": true
+		},
 		"temp-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6085,6 +6926,50 @@
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
 					"integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
 					"dev": true
+				}
+			}
+		},
+		"terser": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+			"integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+			"dev": true,
+			"requires": {
+				"commander": "^2.20.0",
+				"source-map": "~0.7.2",
+				"source-map-support": "~0.5.19"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
+			}
+		},
+		"terser-webpack-plugin": {
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
+			"integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+			"dev": true,
+			"requires": {
+				"jest-worker": "^27.0.2",
+				"p-limit": "^3.1.0",
+				"schema-utils": "^3.0.0",
+				"serialize-javascript": "^6.0.0",
+				"source-map": "^0.6.1",
+				"terser": "^5.7.0"
+			},
+			"dependencies": {
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
 				}
 			}
 		},
@@ -6116,6 +7001,78 @@
 			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
+			}
+		},
+		"ts-loader": {
+			"version": "9.2.5",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.5.tgz",
+			"integrity": "sha512-al/ATFEffybdRMUIr5zMEWQdVnCGMUA9d3fXJ8dBVvBlzytPvIszoG9kZoR+94k6/i293RnVOXwMaWbXhNy9pQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"enhanced-resolve": "^5.0.0",
+				"micromatch": "^4.0.0",
+				"semver": "^7.3.4"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"tslib": {
@@ -6165,9 +7122,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 			"dev": true
 		},
 		"uc.micro": {
@@ -6175,6 +7132,26 @@
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
 			"dev": true
+		},
+		"unbox-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
+			}
 		},
 		"underscore": {
 			"version": "1.8.3",
@@ -6211,6 +7188,20 @@
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
 			"integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
 			"dev": true
+		},
+		"util": {
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+			"integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"safe-buffer": "^5.1.2",
+				"which-typed-array": "^1.1.2"
+			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -6290,6 +7281,213 @@
 				"rimraf": "^2.6.3"
 			}
 		},
+		"watchpack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
+			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"dev": true,
+			"requires": {
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			}
+		},
+		"webpack": {
+			"version": "5.51.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
+			"integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
+			"dev": true,
+			"requires": {
+				"@types/eslint-scope": "^3.7.0",
+				"@types/estree": "^0.0.50",
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/wasm-edit": "1.11.1",
+				"@webassemblyjs/wasm-parser": "1.11.1",
+				"acorn": "^8.4.1",
+				"acorn-import-assertions": "^1.7.6",
+				"browserslist": "^4.14.5",
+				"chrome-trace-event": "^1.0.2",
+				"enhanced-resolve": "^5.8.0",
+				"es-module-lexer": "^0.7.1",
+				"eslint-scope": "5.1.1",
+				"events": "^3.2.0",
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.2.4",
+				"json-parse-better-errors": "^1.0.2",
+				"loader-runner": "^4.2.0",
+				"mime-types": "^2.1.27",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^3.1.0",
+				"tapable": "^2.1.1",
+				"terser-webpack-plugin": "^5.1.3",
+				"watchpack": "^2.2.0",
+				"webpack-sources": "^3.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+					"dev": true
+				},
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"webpack-cli": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
+			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+			"dev": true,
+			"requires": {
+				"@discoveryjs/json-ext": "^0.5.0",
+				"@webpack-cli/configtest": "^1.0.4",
+				"@webpack-cli/info": "^1.3.0",
+				"@webpack-cli/serve": "^1.5.2",
+				"colorette": "^1.2.1",
+				"commander": "^7.0.0",
+				"execa": "^5.0.0",
+				"fastest-levenshtein": "^1.0.12",
+				"import-local": "^3.0.2",
+				"interpret": "^2.2.0",
+				"rechoir": "^0.7.0",
+				"v8-compile-cache": "^2.2.0",
+				"webpack-merge": "^5.7.3"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+					"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.0",
+						"human-signals": "^2.1.0",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.1",
+						"onetime": "^5.1.2",
+						"signal-exit": "^3.0.3",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"dev": true
+				},
+				"human-signals": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+					"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+					"dev": true
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"v8-compile-cache": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+					"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"webpack-merge": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"dev": true,
+			"requires": {
+				"clone-deep": "^4.0.1",
+				"wildcard": "^2.0.0"
+			}
+		},
+		"webpack-sources": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
+			"integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+			"dev": true
+		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -6299,11 +7497,125 @@
 				"isexe": "^2.0.0"
 			}
 		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
+		},
+		"which-typed-array": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.6.tgz",
+			"integrity": "sha512-DdY984dGD5sQ7Tf+x1CkXzdg85b9uEel6nr4UkFg1LoE9OXv3uRuZhe5CoWdawhGACeFpEZXH8fFLQnDhbpm/Q==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.4",
+				"call-bind": "^1.0.2",
+				"es-abstract": "^1.18.5",
+				"foreach": "^2.0.5",
+				"has-tostringtag": "^1.0.0",
+				"is-typed-array": "^1.1.6"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+					"integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
 		},
 		"wide-align": {
 			"version": "1.1.3",
@@ -6346,6 +7658,12 @@
 					}
 				}
 			}
+		},
+		"wildcard": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -6408,6 +7726,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yargs": {
@@ -6492,6 +7816,12 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3"
 			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test": "node ./out/test/runTest.js",
     "package": "vsce package",
     "deploy": "vsce publish",
-    "prepack": "npm run package",
+    "prepack": "npm run package && npm run package-web",
     "compile-web": "webpack --config ./build/web-extension.webpack.config.js",
     "watch-web": "webpack --watch --config ./build/web-extension.webpack.config.js",
     "package-web": "webpack --mode production --devtool hidden-source-map --config ./build/web-extension.webpack.config.js"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     }
   },
   "main": "./out/extension.js",
+  "browser": "./dist/web/extension.js",
   "icon": "icon/path-intellisense.png",
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -68,7 +69,10 @@
     "test": "node ./out/test/runTest.js",
     "package": "vsce package",
     "deploy": "vsce publish",
-    "prepack": "npm run package"
+    "prepack": "npm run package",
+    "compile-web": "webpack --config ./build/web-extension.webpack.config.js",
+    "watch-web": "webpack --watch --config ./build/web-extension.webpack.config.js",
+    "package-web": "webpack --mode production --devtool hidden-source-map --config ./build/web-extension.webpack.config.js"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
@@ -84,9 +88,14 @@
     "eslint": "^6.8.0",
     "glob": "^7.1.6",
     "mocha": "^7.0.1",
-    "typescript": "^3.7.5",
+    "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
+    "ts-loader": "^9.2.5",
+    "typescript": "^3.9.10",
     "vsce": "^1.76.0",
-    "vscode-test": "^1.3.0"
+    "vscode-test": "^1.3.0",
+    "webpack": "^5.51.1",
+    "webpack-cli": "^4.8.0"
   },
   "dependencies": {
     "@types/json5": "0.0.30",


### PR DESCRIPTION
Hello @ChristianKohler  👋

I'm part of the VS Code team and we recently launched VS Code for the web with [github.dev](https://docs.github.com/en/codespaces/developing-in-codespaces/web-based-editor)! You can read the full guide for extension authors creating and migrating extensions here: [Web Extensions
](https://code.visualstudio.com/api/extension-guides/web-extensions)

In hopes to help you migrate I helped make the changes necessary to make your extensions work on the web.

The changes I made:
- Added webpack bundling to bundle your extension into 1 JavaScript file for the web
- Added the compile scripts for webpack to your `package.json`
- Added the necessary dependencies for bundling
- Added the `browser` entry point to your `package.json` to link to the web-friendly compiled extension
- Use 
- Remove all extension uses of `fs` with the [VS Code FileSystemProvider](https://github.com/microsoft/vscode/blob/fc41c9fb60ccb9d9aaa2c62165ed979d69256adc/src/vs/vscode.d.ts#L7190)
- Add fallback for node library `path` with `path-browsersify`