### PR TITLE
feat: allow settings for each folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,46 +38,55 @@
         "path-intellisense.extensionOnImport": {
           "type": "boolean",
           "default": false,
-          "description": "Adds the file extension to a import statements"
+          "description": "Adds the file extension to a import statements",
+          "scope": "resource"
         },
         "path-intellisense.mappings": {
           "type": "object",
           "default": {},
-          "description": "Mappings for paths.  The values should be interpreted as absolute paths (and can use '${workspaceFolder}')"
+          "description": "Mappings for paths.  The values should be interpreted as absolute paths (and can use '${workspaceFolder}')",
+          "scope": "resource"
         },
         "path-intellisense.showHiddenFiles": {
           "type": "boolean",
           "default": false,
-          "description": "Show hidden files"
+          "description": "Show hidden files",
+          "scope": "resource"
         },
         "path-intellisense.autoSlashAfterDirectory": {
           "type": "boolean",
           "default": false,
-          "description": "Automatically adds slash after directory"
+          "description": "Automatically adds slash after directory",
+          "scope": "resource"
         },
         "path-intellisense.absolutePathToWorkspace": {
           "type": "boolean",
           "default": true,
-          "description": "Sets an absolute path to the current workspace"
+          "description": "Sets an absolute path to the current workspace",
+          "scope": "resource"
         },
         "path-intellisense.absolutePathTo": {
           "type": "string",
-          "description": "If defined, unmapped absolute path imports are based on this location.  Takes priority over 'absolutePathToWorkspace' if both are defined"
+          "description": "If defined, unmapped absolute path imports are based on this location.  Takes priority over 'absolutePathToWorkspace' if both are defined",
+          "scope": "resource"
         },
         "path-intellisense.showOnAbsoluteSlash": {
           "type": "boolean",
           "default": true,
-          "description": "Shows suggestions when the import starts with a forward slash ('/')"
+          "description": "Shows suggestions when the import starts with a forward slash ('/')",
+          "scope": "resource"
         },
         "path-intellisense.ignoreTsConfigBaseUrl": {
           "type": "boolean",
           "default": false,
-          "description": "Ignores tsconfig file for mappings"
+          "description": "Ignores tsconfig file for mappings",
+          "scope": "resource"
         },
         "path-intellisense.autoTriggerNextSuggestion": {
           "type": "boolean",
           "default": false,
-          "description": "Automatically triggers next suggestion after previous suggestion"
+          "description": "Automatically triggers next suggestion after previous suggestion",
+          "scope": "resource"
         }
       }
     }


### PR DESCRIPTION
Closes #131 

Multi-root workspaces are supported from https://github.com/ChristianKohler/PathIntellisense/commit/a2eb6791b110929f1c6067bb69a332a0be27f3aa, but could not set settings for each folder.
This PR resolves it.

Before:
![スクリーンショット 2022-07-27 174140](https://user-images.githubusercontent.com/24248467/181203378-0ae94e5c-174b-470d-ab98-0aaa13a39094.png)
![スクリーンショット 2022-07-27 174252](https://user-images.githubusercontent.com/24248467/181203406-9e502b33-667e-4e27-b942-557528afebfa.png)
Folder settings are not applied and no intellisense is displayed.

After:
![スクリーンショット 2022-07-27 174030](https://user-images.githubusercontent.com/24248467/181203463-f52890a1-8baa-49a3-8251-d71ac8719cfb.png)
![スクリーンショット 2022-07-27 174101](https://user-images.githubusercontent.com/24248467/181203476-96661f5f-bcd1-406f-b7e8-d3e1ab808635.png)
Folder settings are applied and intellisense is displayed.