### PR TITLE
Feature/sort-by

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,27 @@
           "type": "boolean",
           "default": false,
           "description": "Automatically triggers next suggestion after previous suggestion"
+        },
+        "path-intellisense.sortBy": {
+          "type": "string",
+          "default": "name",
+          "enum": [
+            "none",
+            "name",
+            "type",
+            "modified",
+            "size",
+            "r-name",
+            "r-type",
+            "r-modified",
+            "r-size"
+          ],
+          "description": "Sorts the suggestions by the selected property"
+        },
+        "path-intellisense.showFoldersBeforeFiles": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show folders before files"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
             "r-modified",
             "r-size"
           ],
-          "description": "Sorts the suggestions by the selected property"
+          "description": "Sorts the suggestions by the selected property. r-* sorts in reverse order of that property"
         },
         "path-intellisense.showFoldersBeforeFiles": {
           "type": "boolean",

--- a/src/configuration/configuration.interface.ts
+++ b/src/configuration/configuration.interface.ts
@@ -1,3 +1,5 @@
+export type SortBy = 'none' | 'name' | 'type' | 'modified' | 'size' | 'r-name' | 'r-type' | 'r-modified' | 'r-size';
+
 export interface Config {
   autoSlash: boolean;
   autoTrigger: boolean;
@@ -8,6 +10,8 @@ export interface Config {
   absolutePathTo: string | null;
   showOnAbsoluteSlash: boolean;
   filesExclude: FilesExclude;
+  sortBy: SortBy;
+  showFoldersBeforeFiles: boolean;
 }
 
 export interface FilesExclude {

--- a/src/configuration/configuration.service.ts
+++ b/src/configuration/configuration.service.ts
@@ -29,6 +29,8 @@ export async function getConfiguration(
     showOnAbsoluteSlash: cfgExtension["showOnAbsoluteSlash"],
     filesExclude: cfgGeneral["exclude"],
     mappings,
+    sortBy: cfgExtension["sortBy"],
+    showFoldersBeforeFiles: cfgExtension["showFoldersBeforeFiles"],
   };
 }
 

--- a/src/providers/javascript/javascript.provider.ts
+++ b/src/providers/javascript/javascript.provider.ts
@@ -86,7 +86,8 @@ async function provide(
   const childrenOfPath = await getChildrenOfPath(
     path,
     config.showHiddenFiles,
-    config.filesExclude
+    config.filesExclude,
+    { sortBy: config.sortBy, showFoldersBeforeFiles: config.showFoldersBeforeFiles }
   );
 
   return [

--- a/src/providers/nixos/nixos.provider.ts
+++ b/src/providers/nixos/nixos.provider.ts
@@ -95,7 +95,8 @@ async function provide(
   const childrenOfPath = await getChildrenOfPath(
     path,
     config.showHiddenFiles,
-    config.filesExclude
+    config.filesExclude,
+    { sortBy: config.sortBy, showFoldersBeforeFiles: config.showFoldersBeforeFiles }
   );
 
   return [

--- a/src/utils/createCompletionItem.ts
+++ b/src/utils/createCompletionItem.ts
@@ -30,7 +30,7 @@ function createFolderItem(
   return {
     label: fileInfo.file,
     kind: vscode.CompletionItemKind.Folder,
-    sortText: `a_${fileInfo.file}`,
+    sortText: fileInfo.sortKey,
     range: importRange,
     insertText: newText,
     command: autoTrigger
@@ -52,7 +52,7 @@ function createFileItem(
   return {
     label: fileInfo.file,
     kind: vscode.CompletionItemKind.File,
-    sortText: `b_${fileInfo.file}`,
+    sortText: fileInfo.sortKey,
     range: context.importRange,
     insertText: insertText,
   };


### PR DESCRIPTION
add configuration to sort the provided results by: name (default), size, mtime, type. for each one there's a reversed variant of it.
add configuration to keep the folders results first (sorting folders and files seperatly, and then concat the results). default to true.